### PR TITLE
Fix exception if no SITE_ID is set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,43 +1,13 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.4"
   - "3.5"
 env:
-  - DJANGO='Django==1.4.*'
-  - DJANGO='Django==1.5.*'
-  - DJANGO='Django==1.6.*'
-  - DJANGO='Django==1.7.*'
   - DJANGO='Django==1.8.*'
   - DJANGO='Django==1.9.*'
   - DJANGO='Django==1.10.*'
   - DJANGO='Django==1.11.*'
-matrix:
-  exclude:
-    # Django >= 1.7 does not support Python 2.6
-    - python: "2.6"
-      env: DJANGO='Django==1.7.*'
-    - python: "2.6"
-      env: DJANGO='Django==1.8.*'
-    - python: "2.6"
-      env: DJANGO='Django==1.9.*'
-    # Django < 1.7 does not support Python 3.4
-    - python: "3.4"
-      env: DJANGO='Django==1.4.*'
-    - python: "3.4"
-      env: DJANGO='Django==1.5.*'
-    - python: "3.4"
-      env: DJANGO='Django==1.6.*'
-    # Django < 1.8 does not support Python 3.5
-    - python: "3.5"
-      env: DJANGO='Django==1.4.*'
-    - python: "3.5"
-      env: DJANGO='Django==1.5.*'
-    - python: "3.5"
-      env: DJANGO='Django==1.6.*'
-    - python: "3.5"
-      env: DJANGO='Django==1.7.*'
 install:
   - pip install $DJANGO
 script:

--- a/subdomains/middleware.py
+++ b/subdomains/middleware.py
@@ -28,7 +28,7 @@ class SubdomainMiddleware(MiddlewareMixin):
         Returns the domain that will be used to identify the subdomain part
         for this request.
         """
-        return get_domain()
+        return get_domain(request)
 
     def process_request(self, request):
         """

--- a/subdomains/tests/tests.py
+++ b/subdomains/tests/tests.py
@@ -44,7 +44,18 @@ class SubdomainTestMixin(object):
         MIDDLEWARE_CLASSES=(
             'django.middleware.common.CommonMiddleware',
             'subdomains.middleware.SubdomainURLRoutingMiddleware',
-        ))
+        ),
+        TEMPLATES=[
+            {
+                'BACKEND': 'django.template.backends.django.DjangoTemplates',
+                'DIRS': [],
+                'APP_DIRS': True,
+                'OPTIONS': {
+                    # ... some options here ...
+                },
+            },
+        ],
+        ALLOWED_HOSTS=['*'])
     def run(self, *args, **kwargs):
         super(SubdomainTestMixin, self).run(*args, **kwargs)
 

--- a/subdomains/tests/urls/api.py
+++ b/subdomains/tests/urls/api.py
@@ -1,13 +1,10 @@
-try:
-    from django.conf.urls import patterns, url
-except ImportError:
-    from django.conf.urls.defaults import patterns, url  # noqa
+from django.conf.urls import url
 
 from subdomains.tests.urls.default import urlpatterns as default_patterns
 from subdomains.tests.views import view
 
 
-urlpatterns = default_patterns + patterns('',
+urlpatterns = default_patterns + [
     url(regex=r'^$', view=view, name='home'),
     url(regex=r'^view/$', view=view, name='view'),
-)
+]

--- a/subdomains/tests/urls/application.py
+++ b/subdomains/tests/urls/application.py
@@ -1,13 +1,10 @@
-try:
-    from django.conf.urls import patterns, url
-except ImportError:
-    from django.conf.urls.defaults import patterns, url  # noqa
+from django.conf.urls import url
 
 from subdomains.tests.urls.default import urlpatterns as default_patterns
 from subdomains.tests.views import view
 
 
-urlpatterns = default_patterns + patterns('',
+urlpatterns = default_patterns + [
     url(regex=r'^view/$', view=view, name='view'),
     url(regex=r'^application/$', view=view, name='application'),
-)
+]

--- a/subdomains/tests/urls/default.py
+++ b/subdomains/tests/urls/default.py
@@ -1,12 +1,9 @@
-try:
-    from django.conf.urls import patterns, url
-except ImportError:
-    from django.conf.urls.defaults import patterns, url  # noqa
+from django.conf.urls import url
 
 from subdomains.tests.views import view
 
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(regex=r'^$', view=view, name='home'),
     url(regex=r'^example/$', view=view, name='example'),
-)
+]

--- a/subdomains/tests/urls/marketing.py
+++ b/subdomains/tests/urls/marketing.py
@@ -1,8 +1,3 @@
-try:
-    from django.conf.urls import patterns, url
-except ImportError:
-    from django.conf.urls.defaults import patterns, url  # noqa
-
 from subdomains.tests.urls.default import urlpatterns as default_patterns
 
 

--- a/subdomains/utils.py
+++ b/subdomains/utils.py
@@ -8,9 +8,9 @@ from django.conf import settings
 from django.core.urlresolvers import reverse as simple_reverse
 
 
-def current_site_domain():
+def current_site_domain(request):
     from django.contrib.sites.models import Site
-    domain = Site.objects.get_current().domain
+    domain = Site.objects.get_current(request).domain
 
     prefix = 'www.'
     if getattr(settings, 'REMOVE_WWW_FROM_DOMAIN', False) \

--- a/subdomains/utils.py
+++ b/subdomains/utils.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.core.urlresolvers import reverse as simple_reverse
 
 
-def current_site_domain(request):
+def current_site_domain(request=None):
     from django.contrib.sites.models import Site
     domain = Site.objects.get_current(request).domain
 

--- a/subdomains/utils.py
+++ b/subdomains/utils.py
@@ -6,11 +6,23 @@ except ImportError:
 
 from django.conf import settings
 from django.core.urlresolvers import reverse as simple_reverse
+from django.core.exceptions import ImproperlyConfigured
 
 
 def current_site_domain(request=None):
-    from django.contrib.sites.models import Site
-    domain = Site.objects.get_current(request).domain
+    from django.conf import settings
+    if getattr(settings, 'SITE_ID', ''):
+        from django.contrib.sites.models import Site
+        domain = Site.objects.get_current(request).domain
+    elif getattr(settings, 'ROOT_DOMAIN', ''):
+        domain = getattr(settings, 'ROOT_DOMAIN', '')
+    else:
+        raise ImproperlyConfigured(
+            "You're using the \"subdomains framework\" without having "
+            "set the SITE_ID setting. Create a site in your database and "
+            "set the SITE_ID setting or set the ROOT_DOMAIN setting "
+            "to fix this error."
+        )
 
     prefix = 'www.'
     if getattr(settings, 'REMOVE_WWW_FROM_DOMAIN', False) \


### PR DESCRIPTION
If no SITE_ID is in the settings file, the `Site.objects.get_current()` method should be called with the request to correctly lookup the current site.