### PR TITLE
Fix reverse imports for Django 2.0

### DIFF
--- a/subdomains/utils.py
+++ b/subdomains/utils.py
@@ -5,7 +5,10 @@ except ImportError:
     from urllib.parse import urlunparse
 
 from django.conf import settings
-from django.core.urlresolvers import reverse as simple_reverse
+try:
+    from django.urls import reverse as simple_reverse
+except:
+    from django.core.urlresolvers import reverse as simple_reverse
 
 
 def current_site_domain():

--- a/subdomains/utils.py
+++ b/subdomains/utils.py
@@ -6,9 +6,9 @@ except ImportError:
 
 from django.conf import settings
 try:
-    from django.urls import reverse as simple_reverse
-except:
     from django.core.urlresolvers import reverse as simple_reverse
+except ImportError:
+    from django.urls import reverse as simple_reverse
 
 
 def current_site_domain():


### PR DESCRIPTION
Django 2.0 changed the import path for the `reverse` function, this PR fixes this in a backwards compatible way.